### PR TITLE
Fixed terminal behaviour when app becomes active with no active windows

### DIFF
--- a/main.m
+++ b/main.m
@@ -247,6 +247,13 @@
 		object: nil];
 }
 
+- (void) applicationDidBecomeActive: (NSNotification *) notification
+{
+	if (TerminalWindowController.numberOfActiveWindows == 0) {
+		[self openWindow: self];
+	}
+}
+
 -(void) openWindow: (id)sender
 {
 	TerminalWindowController *twc;
@@ -321,8 +328,6 @@
 			initialInput: nil];
                 [twc release];
 	}
-	else
-		[self openWindow: self];
 }
 
 


### PR DESCRIPTION
Formerly, the Terminal app could be made active with no open windows, and nothing in particular would happen; this patch fixes it so that when the app becomes active, if there are no active windows, a new shell window is created and opened. This includes when the application is first run.
