### PR TITLE
Made UTF-8 the default in Prefs instead of the anachronic ISO-8859-1

### DIFF
--- a/TerminalParser_LinuxPrefs.m
+++ b/TerminalParser_LinuxPrefs.m
@@ -59,7 +59,7 @@ static character_set_choice_t cs_choices[]={
 
 		characterSet=[[ud stringForKey: CharacterSetKey] retain];
 		if (!characterSet)
-			characterSet=@"iso-8859-1";
+			characterSet=@"utf-8";
 	}
 }
 


### PR DESCRIPTION
This makes sure that upon first install when no Terminal.plist exists the Terminal app defaults to utf-8. I assume the aim of AgoraDesktop isn't to run on versions of FreeBSD that don't support UTF-8. You can easily check it works by installing midnight commander on a new install, which is how I noticed it defaulted to the very western ISO-8859-1 which didn't match the system (FreeBSD 13.2 clean AARCH64 install in my case).